### PR TITLE
Fsfw cli

### DIFF
--- a/src/main/perl/FSFW-CLI/FSFW-CLI.spec
+++ b/src/main/perl/FSFW-CLI/FSFW-CLI.spec
@@ -12,8 +12,8 @@ Requires: perl
 Requires: perl-Term-ReadLine-Gnu
 Requires: perl-GRNOC-Config
 Requires: perl-GRNOC-WebService-Client
-Requires: perl-Data-Dumper
-Requires: perl-FindBin
+
+
 
 
 %description


### PR DESCRIPTION
Fixed Requires in spec to not include Data Dumper or FindBin, as they're perl core.
