### PR TITLE
1.0.3 dev

### DIFF
--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/XidMap.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/XidMap.java
@@ -29,7 +29,7 @@ public class XidMap {
 
 	private Map<Integer, Integer> xidMap;
 	private static final int max_xid_size = 1000;
-	@SuppressWarnings("unused")
+	
 	private static final Logger log = LoggerFactory.getLogger(XidMap.class);
 	
 	public XidMap(){

--- a/src/test/java/edu/iu/grnoc/flowspace_firewall/FlowStatSlicerTest.java
+++ b/src/test/java/edu/iu/grnoc/flowspace_firewall/FlowStatSlicerTest.java
@@ -31,11 +31,14 @@ import net.floodlightcontroller.core.ImmutablePort;
 import org.junit.Test;
 import org.junit.Before;
 import org.openflow.protocol.OFMatch;
+import org.openflow.protocol.Wildcards.Flag;
 import org.openflow.protocol.action.OFAction;
 import org.openflow.protocol.action.OFActionOutput;
 import org.openflow.protocol.action.OFActionVirtualLanIdentifier;
 import org.openflow.protocol.statistics.OFFlowStatisticsReply;
 import org.openflow.protocol.statistics.OFStatistics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
@@ -51,6 +54,7 @@ public class FlowStatSlicerTest {
 	PortConfig pConfig2;
 	PortConfig pConfig3;
 	PortConfig pConfig5;
+	protected static Logger log = LoggerFactory.getLogger(FlowStatSlicerTest.class);
 	
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();
@@ -64,7 +68,8 @@ public class FlowStatSlicerTest {
 		OFMatch match = new OFMatch();
 		match.setInputPort((short)1);
 		match.setDataLayerVirtualLan((short)100);
-		
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
 		//all allowed stats
 		allowedStats = new ArrayList<OFStatistics>();
 		OFFlowStatisticsReply stat = new OFFlowStatisticsReply();
@@ -80,6 +85,8 @@ public class FlowStatSlicerTest {
 		match = new OFMatch();
 		match.setInputPort((short)2);
 		match.setDataLayerVirtualLan((short)102);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
 		stat = new OFFlowStatisticsReply();
 		stat.setActions(actions);
 		stat.setMatch(match);
@@ -93,6 +100,8 @@ public class FlowStatSlicerTest {
 		match = new OFMatch();
 		match.setInputPort((short)3);
 		match.setDataLayerVirtualLan((short)103);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
 		stat = new OFFlowStatisticsReply();
 		stat.setActions(actions);
 		stat.setMatch(match);
@@ -106,6 +115,8 @@ public class FlowStatSlicerTest {
 		match = new OFMatch();
 		match.setInputPort((short)5);
 		match.setDataLayerVirtualLan((short)105);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
 		stat = new OFFlowStatisticsReply();
 		stat.setActions(actions);
 		stat.setMatch(match);
@@ -139,6 +150,8 @@ public class FlowStatSlicerTest {
 		match = new OFMatch();
 		match.setInputPort((short)2);
 		match.setDataLayerVirtualLan((short)202);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
 		stat = new OFFlowStatisticsReply();
 		stat.setActions(actions);
 		stat.setMatch(match);
@@ -155,6 +168,8 @@ public class FlowStatSlicerTest {
 		match = new OFMatch();
 		match.setInputPort((short)3);
 		match.setDataLayerVirtualLan((short)103);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
 		stat = new OFFlowStatisticsReply();
 		stat.setActions(actions);
 		stat.setMatch(match);
@@ -168,6 +183,8 @@ public class FlowStatSlicerTest {
 		match = new OFMatch();
 		match.setInputPort((short)5);
 		match.setDataLayerVirtualLan((short)105);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
 		stat = new OFFlowStatisticsReply();
 		stat.setActions(actions);
 		stat.setMatch(match);
@@ -181,6 +198,8 @@ public class FlowStatSlicerTest {
 		match = new OFMatch();
 		match.setInputPort((short)5);
 		match.setDataLayerVirtualLan((short)105);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
 		stat = new OFFlowStatisticsReply();
 		stat.setActions(actions);
 		stat.setMatch(match);
@@ -194,6 +213,9 @@ public class FlowStatSlicerTest {
 		match = new OFMatch();
 		match.setInputPort((short)4);
 		match.setDataLayerVirtualLan((short)105);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
+		
 		stat = new OFFlowStatisticsReply();
 		stat.setActions(actions);
 		stat.setMatch(match);
@@ -253,6 +275,7 @@ public class FlowStatSlicerTest {
 		
 		sw = createMock(IOFSwitch.class);
 		expect(sw.getId()).andReturn(0L).anyTimes();
+		expect(sw.getStringId()).andReturn("0000000").anyTimes();
 		expect(sw.getPort((short)1)).andReturn(p).anyTimes();
 		expect(sw.getPort((short)2)).andReturn(p2).anyTimes();
 		expect(sw.getPort((short)3)).andReturn(p3).anyTimes();
@@ -307,7 +330,7 @@ public class FlowStatSlicerTest {
 	@Test
 	public void testSliceStatsAllAllowed() {
 		List <OFStatistics> slicedStats = FlowStatSlicer.SliceStats(slicer, allowedStats);
-		assertEquals("Number of sliced stat is same as number of total stats", slicedStats.size(), allowedStats.size());
+		assertEquals("Number of sliced stat is same as number of total stats",  allowedStats.size(),slicedStats.size());
 	}
 	
 	@Test

--- a/src/test/java/edu/iu/grnoc/flowspace_firewall/ProxyTest.java
+++ b/src/test/java/edu/iu/grnoc/flowspace_firewall/ProxyTest.java
@@ -45,6 +45,7 @@ import org.junit.Before;
 import org.junit.rules.ExpectedException;
 import org.openflow.protocol.*;
 import org.openflow.protocol.OFError.OFErrorType;
+import org.openflow.protocol.Wildcards.Flag;
 import org.openflow.protocol.action.*;
 import org.openflow.protocol.statistics.OFStatistics;
 import org.slf4j.Logger;
@@ -388,6 +389,8 @@ public class ProxyTest {
 		OFMatch match = new OFMatch();
 		match.setDataLayerVirtualLan((short)100);
 		match.setInputPort((short)1);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
 		List<OFAction> actions = new ArrayList<OFAction>();
 		OFActionVirtualLanIdentifier act1 = new OFActionVirtualLanIdentifier();
 		act1.setVirtualLanIdentifier((short)102);
@@ -428,6 +431,8 @@ public class ProxyTest {
 		OFMatch match = new OFMatch();
 		match.setDataLayerVirtualLan((short)100);
 		match.setInputPort((short)1);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
 		List<OFAction> actions = new ArrayList<OFAction>();
 				
 		//create the output action
@@ -474,6 +479,8 @@ public class ProxyTest {
 		OFMatch match = new OFMatch();
 		match.setDataLayerVirtualLan((short)100);
 		match.setInputPort((short)1);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
 		List<OFAction> actions = new ArrayList<OFAction>();
 				
 		//create the output action
@@ -502,7 +509,8 @@ public class ProxyTest {
 		assertTrue("1 message went to the controller", messagesSentToController.size() == 1);
 		OFMessage msg = messagesSentToController.get(0);
 		assertTrue("Message to Controller was an error", msg.getType().getTypeValue() == OFMessageType.ERROR.getValue());
-		
+		OFError error = (OFError)msg;
+		assertTrue("Error type is now OFPET_FLOW_MOD_FAILED", error.getErrorType() == OFError.OFErrorType.OFPET_FLOW_MOD_FAILED.getValue());
 	}
 	
 	
@@ -792,6 +800,51 @@ public class ProxyTest {
 	}
 	
 	@Test
+	public void testWildCardErrorReturned(){
+		setupSlicer();
+		messagesSentToSwitch.clear();
+		messagesSentToController.clear();
+		Proxy proxy = new Proxy(sw, slicer, fsfw);
+		expect(channel.isConnected()).andReturn(true).anyTimes();
+		expect(handler.isHandshakeComplete()).andReturn(true).anyTimes();
+		EasyMock.replay(handler);
+		EasyMock.replay(channel);
+		assertNotNull("Proxy was created",proxy);
+		assertFalse("Proxy is not connected as expected", proxy.connected());
+		proxy.connect(channel);
+		assertTrue("Proxy is now connected", proxy.connected());
+		
+		//build the match
+		OFMatch match = new OFMatch();
+		match.setDataLayerVirtualLan((short)100);
+		match.setInputPort((short)1);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
+		List<OFAction> actions = new ArrayList<OFAction>();
+				
+		//create the output action
+		OFActionOutput act2 = new OFActionOutput();
+		act2.setPort((short)1);
+		act2.setType(OFActionType.OUTPUT);
+		
+		//add the actions to the action list
+		actions.add(act2);
+				
+		//build the flow
+		OFFlowMod flow = new OFFlowMod();
+		flow.setCommand(OFFlowMod.OFPFC_ADD);
+		flow.setXid(101);
+		flow.setMatch(match);
+		flow.setActions(actions);
+		flow.setLengthU(80);
+		proxy.toSwitch(flow, cntx);
+		
+		log.debug(messagesSentToSwitch.toString());
+		assertTrue("Message was sent to Switch", messagesSentToSwitch.size() == 0);
+		assertTrue("Message was not sent to Controller", messagesSentToController.size() == 1);
+		
+	}
+	
+	@Test
 	public void testErrorReturnedNotPartOfSlice(){
 		setupSlicer();
 		messagesSentToSwitch.clear();
@@ -810,6 +863,8 @@ public class ProxyTest {
 		OFMatch match = new OFMatch();
 		match.setDataLayerVirtualLan((short)100);
 		match.setInputPort((short)1);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
 		List<OFAction> actions = new ArrayList<OFAction>();
 				
 		//create the output action
@@ -856,9 +911,6 @@ public class ProxyTest {
 		assertFalse("Proxy is not connected as expected", proxy.connected());
 		proxy.connect(channel);
 		assertTrue("Proxy is now connected", proxy.connected());
-		
-		
-		
 	}
 	
 	@Test
@@ -1110,6 +1162,8 @@ public class ProxyTest {
 		OFMatch match = new OFMatch();
 		match.setDataLayerVirtualLan((short)100);
 		match.setInputPort((short)1);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
 		List<OFAction> actions = new ArrayList<OFAction>();
 		OFActionVirtualLanIdentifier act1 = new OFActionVirtualLanIdentifier();
 		act1.setVirtualLanIdentifier((short)102);
@@ -1169,6 +1223,8 @@ public class ProxyTest {
 		OFMatch match = new OFMatch();
 		match.setDataLayerVirtualLan((short)100);
 		match.setInputPort((short)1);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
 		List<OFAction> actions = new ArrayList<OFAction>();
 		OFActionVirtualLanIdentifier act1 = new OFActionVirtualLanIdentifier();
 		act1.setVirtualLanIdentifier((short)102);

--- a/src/test/java/edu/iu/grnoc/flowspace_firewall/VLANSlicerTest.java
+++ b/src/test/java/edu/iu/grnoc/flowspace_firewall/VLANSlicerTest.java
@@ -36,6 +36,7 @@ import org.openflow.protocol.OFMatch;
 import org.openflow.protocol.OFMessage;
 import org.openflow.protocol.OFPacketOut;
 import org.openflow.protocol.OFPort;
+import org.openflow.protocol.Wildcards.Flag;
 import org.openflow.protocol.action.OFAction;
 import org.openflow.protocol.action.OFActionOutput;
 import org.openflow.protocol.action.OFActionType;
@@ -291,6 +292,8 @@ public class VLANSlicerTest {
 		OFMatch match = new OFMatch();
 		match.setInputPort((short)1);
 		match.setDataLayerVirtualLan((short)100);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
 		flow.setMatch(match);
 		flow.setActions(actions);
 
@@ -321,6 +324,7 @@ public class VLANSlicerTest {
 		match = new OFMatch();
 		match.setInputPort((short)0);
 		match.setDataLayerVirtualLan((short)1000);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
 		flow.setMatch(match);
 		flow.setActions(actions);
 		flows = slicer.allowedFlows(flow);
@@ -356,6 +360,8 @@ public class VLANSlicerTest {
 		OFMatch match = new OFMatch();
 		match.setInputPort((short)1);
 		match.setDataLayerVirtualLan((short)1000);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
 		flow.setMatch(match);
 		List<OFAction> actions = new ArrayList<OFAction>();
 		OFActionVirtualLanIdentifier setVid = new OFActionVirtualLanIdentifier();
@@ -389,6 +395,7 @@ public class VLANSlicerTest {
 		OFMatch match = new OFMatch();
 		match.setInputPort((short)0);
 		match.setDataLayerVirtualLan((short)1000);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
 		flow.setMatch(match);
 		flow.setActions(actions);
 		List<OFFlowMod>flows = slicer.allowedFlows(flow);
@@ -435,6 +442,8 @@ public class VLANSlicerTest {
 		OFMatch match = new OFMatch();
 		match.setInputPort((short)1);
 		match.setDataLayerVirtualLan((short)1000);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
 		flow.setMatch(match);
 		flow.setActions(actions);
 		
@@ -481,6 +490,7 @@ public class VLANSlicerTest {
 		OFMatch match = new OFMatch();
 		match.setInputPort((short)0);
 		match.setDataLayerVirtualLan((short)1000);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
 		flow.setMatch(match);
 		flow.setActions(actions);
 		


### PR DESCRIPTION
fixed a possible bypass mechanism where you can set the in_port/vlan tag but do not specify it in the wildcards.  Causing a potential bypass around FSFW's restrictions this is #54
