### PR TITLE
found a synchronization issue with the connector

### DIFF
--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/ControllerConnector.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/ControllerConnector.java
@@ -91,7 +91,7 @@ public class ControllerConnector extends TimerTask {
 	 * Looks through every proxy and determines if the proxy needs to 
 	 * attempt to connect to the controller.
 	 */
-	public void run(){
+	public synchronized void run(){
 		log.debug("Looking for controllers not currently connected");
 		Iterator <Long> it = proxies.keySet().iterator();
 		while(it.hasNext()){


### PR DESCRIPTION
I found an intermittent problem with the controller connector.  If you
manage to do a reload at the exact same moment that the controller
connector is running, you can cause an exception in the controller
connector thread and prevent FSFW from connecting to controllers.
