### PR TITLE
ISSUE=9529 flow stat cache thread dies

### DIFF
--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/FlowSpaceFirewall.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/FlowSpaceFirewall.java
@@ -67,7 +67,7 @@ public class FlowSpaceFirewall implements IFloodlightModule, IOFMessageListener,
     private Timer controllerConnectTimer;
     
     private ArrayList<HashMap<Long, Slicer>> slices;
-    private ArrayList<IOFSwitch> switches;
+    private List<IOFSwitch> switches;
     private FlowStatCacher statsCacher;
     private ControllerConnector controllerConnector;
     protected IRestApiService restApi;
@@ -436,7 +436,7 @@ public class FlowSpaceFirewall implements IFloodlightModule, IOFMessageListener,
 		floodlightProvider.addOFMessageListener(OFType.PORT_STATUS, this);
 		floodlightProvider.addOFMessageListener(OFType.ERROR,this);
 		floodlightProvider.addOFMessageListener(OFType.FLOW_REMOVED, this);
-		switches = new ArrayList<IOFSwitch>();
+		switches = Collections.synchronizedList(new ArrayList<IOFSwitch>());
 		//start up the stats collector timer
 		statsTimer = new Timer("StatsTimer");
 		statsCacher = new FlowStatCacher(this);

--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/FlowStatCache.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/FlowStatCache.java
@@ -87,7 +87,11 @@ public class FlowStatCache {
 			if(slicedCache.containsKey(switchId)){
 				HashMap<String, List<OFStatistics>> slicedStats = slicedCache.get(switchId);
 				slicedStats.put(slice.getSliceName(), FlowStatSlicer.SliceStats(slice,stats));
-				this.parent.getProxy(switchId, slice.getSliceName()).setFlowCount(slicedStats.get(slice.getSliceName()).size());
+				Proxy p = this.parent.getProxy(switchId, slice.getSliceName());
+				if(p == null){
+					return;
+				}
+				p.setFlowCount(slicedStats.get(slice.getSliceName()).size());
 			}
 		}
 	}
@@ -101,7 +105,11 @@ public class FlowStatCache {
 				//switch not part of this slice
 				continue;
 			}
-			flowTimeouts.addAll( this.parent.getProxy(switchId, tmpSlices.get(switchId).getSliceName()).getTimeouts());
+			Proxy proxy = this.parent.getProxy(switchId, tmpSlices.get(switchId).getSliceName());
+			if(proxy == null){
+				return flowTimeouts;
+			}
+			flowTimeouts.addAll( proxy.getTimeouts());
 		}
 			
 		return flowTimeouts;
@@ -115,7 +123,11 @@ public class FlowStatCache {
 				//switch not part of this slice
 				continue;
 			}
-			this.parent.getProxy(switchId, tmpSlices.get(switchId).getSliceName()).checkExpiredFlows();
+			Proxy p = this.parent.getProxy(switchId, tmpSlices.get(switchId).getSliceName());
+			if(p == null){
+				return;
+			}
+			p.checkExpiredFlows();
 		}
 	}
 	


### PR DESCRIPTION
In some circumstances the flow stat cacher thread is dying.  Its
related to a null pointer exception related to getProxy returning null
when the proxy is not found.  I fixed this in several locations.  While
trouble shooting we also found a potential synchronization issue with
the FlowSpaceFirewall.java class this.switches object not being
synchornized
