### PR TITLE
ISSUE=9448 improved logging

### DIFF
--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/ConfigParser.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/ConfigParser.java
@@ -154,6 +154,7 @@ public final class ConfigParser {
 	        				if(tag_mgmt != null){
 	        					tag_management = Boolean.parseBoolean(switchConfig.getAttributes().getNamedItem("tag_management").getTextContent());
 	        				}
+	        				slicer.setSwitchName(switchConfig.getAttributes().getNamedItem("name").getTextContent());
 	        				slicer.setTagManagement(tag_management);
 	        				slicer.setFlushRulesOnConnect(flush_on_connect);
 	        				int numberOfFlows = Integer.parseInt(switchConfig.getAttributes().getNamedItem("max_flows").getTextContent());

--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/FlowSpaceFirewall.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/FlowSpaceFirewall.java
@@ -284,7 +284,7 @@ public class FlowSpaceFirewall implements IFloodlightModule, IOFMessageListener,
 				
 				if(!updated){
 					logger.warn("Slice "
-							+p.getSlicer().getSliceName()+":" + p.getSwitch().getStringId() +" was not found, removing");
+							+p.getSlicer().getSliceName()+":" + p.getSlicer().getSwitchName() +" was not found, removing");
 					p.disconnect();
 					toBeRemoved.add(p);
 				}
@@ -359,7 +359,7 @@ public class FlowSpaceFirewall implements IFloodlightModule, IOFMessageListener,
 				logger.debug("slice disabled... skipping");
 			}else{
 				try{
-					logger.debug("attempting to send " + msg.toString() + " to slice: " + p.getSlicer().getSliceName() + " from switch: " + sw.getStringId());
+					logger.debug("attempting to send " + msg.toString() + " to slice: " + p.getSlicer().getSliceName() + " from switch: " + p.getSlicer().getSwitchName());
 					p.toController(msg,cntx);
 				}catch (Exception e){
 					//don't die please... just keep going and error the stack trace

--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/Proxy.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/Proxy.java
@@ -286,7 +286,7 @@ public class Proxy {
 	}
 	
 	public void setFlowCount(int totalFlows){
-		log.debug("set flow count to: " + totalFlows + " for slice " + this.getSlicer().getSliceName() + " " + this.getSwitch().getStringId());
+		log.debug("set flow count to: " + totalFlows + " for slice " + this.getSlicer().getSliceName() + " " + this.getSlicer().getSwitchName());
 		this.flowCount = totalFlows;
 	}
 	
@@ -335,25 +335,25 @@ public class Proxy {
 		if(this.mySlicer.getTagManagement()){
 			flows = this.mySlicer.managedFlows((OFFlowMod)msg);
 			if(flows.size() ==0){
-				log.error("Slice: " + this.mySlicer.getSliceName() + ":" + this.mySwitch.getStringId() + " denied flow: " + ((OFFlowMod)msg).toString());
+				log.error("Slice: " + this.mySlicer.getSliceName() + ":" + this.getSlicer().getSwitchName() + " denied flow: " + ((OFFlowMod)msg).toString());
 				OFError error = new OFError(OFError.OFErrorType.OFPET_BAD_REQUEST);
 				error.setErrorCode(OFBadRequestCode.OFPBRC_EPERM);
 				this.sendError((OFMessage)msg,error );
 				return;
 			}else{
-				log.info("Slice: " + this.mySlicer.getSliceName() + ":" + this.mySwitch.getStringId() + " Sent Flow: " + ((OFFlowMod)msg).toString());
+				log.info("Slice: " + this.mySlicer.getSliceName() + ":" + this.getSlicer().getSwitchName() + " Sent Flow: " + ((OFFlowMod)msg).toString());
 			}
 		}else{
 			flows = this.mySlicer.allowedFlows((OFFlowMod)msg);
 			if(flows.size() == 0){
 				//really we need to send a perm error
-				log.error("Slice: " + this.mySlicer.getSliceName() + ":" + this.mySwitch.getStringId() + " denied flow: " + ((OFFlowMod)msg).toString());
+				log.error("Slice: " + this.mySlicer.getSliceName() + ":" + this.getSlicer().getSwitchName() + " denied flow: " + ((OFFlowMod)msg).toString());
 				OFError error = new OFError(OFError.OFErrorType.OFPET_BAD_REQUEST);
 				error.setErrorCode(OFBadRequestCode.OFPBRC_EPERM);
 				this.sendError((OFMessage)msg,error);
 				return;
 			}else{
-				log.info("Slice: " + this.mySlicer.getSliceName() + ":" + this.mySwitch.getStringId() + " Sent Flow: " + ((OFFlowMod)msg).toString());
+				log.info("Slice: " + this.mySlicer.getSliceName() + ":" + this.getSlicer().getSwitchName() + " Sent Flow: " + ((OFFlowMod)msg).toString());
 			}
 		}
 		List <OFMessage> messages = new ArrayList<OFMessage>();
@@ -366,7 +366,7 @@ public class Proxy {
 			case OFFlowMod.OFPFC_ADD:
 
 				if( this.mySlicer.isGreaterThanMaxFlows(this.flowCount + 1) ) {
-					log.warn("Switch: "+this.mySwitch.getStringId()+" Slice: "+this.mySlicer.getSliceName()+" Flow count is already at threshold. Skipping flow mod");
+					log.warn("Switch: "+this.getSlicer().getSwitchName()+" Slice: "+this.mySlicer.getSliceName()+" Flow count is already at threshold. Skipping flow mod");
 					OFError error = new OFError(OFError.OFErrorType.OFPET_FLOW_MOD_FAILED);
 					error.setErrorCode(OFError.OFFlowModFailedCode.OFPFMFC_ALL_TABLES_FULL);
 					this.sendError((OFMessage)msg, error);
@@ -392,7 +392,7 @@ public class Proxy {
 			case OFFlowMod.OFPFF_CHECK_OVERLAP:
 
 				if( this.mySlicer.isGreaterThanMaxFlows(this.flowCount + 1) ) {
-					log.warn("Switch: "+this.mySwitch.getStringId()+" Slice: "+this.mySlicer.getSliceName()+"Flow count is already at threshold. Skipping flow mod");
+					log.warn("Switch: "+this.getSlicer().getSwitchName()+" Slice: "+this.mySlicer.getSliceName()+"Flow count is already at threshold. Skipping flow mod");
 					OFError error = new OFError(OFError.OFErrorType.OFPET_FLOW_MOD_FAILED);
 					error.setErrorCode(OFError.OFFlowModFailedCode.OFPFMFC_ALL_TABLES_FULL);
 					this.sendError((OFMessage)msg,error);
@@ -615,7 +615,7 @@ public class Proxy {
 	
 	private void handleFlowStatsRequest(OFMessage msg){
 		//we have the stats cached so slice n' dice and return
-		log.debug("Working on stats for switch: " + mySwitch.getStringId() + " for slice this slice");
+		log.debug("Working on stats for switch: " + this.getSlicer().getSwitchName() + " for slice this slice");
 		List<OFStatistics> results = this.parent.getSlicedFlowStats(mySwitch.getId(),this.mySlicer.getSliceName());
 		
 		if(results == null){
@@ -699,7 +699,7 @@ public class Proxy {
 		//first figure out what the message is
 		log.debug("Proxy Slicing request of type: " + msg.getType());
 		if(!this.mySlicer.isOkToProcessMessage()){
-			log.warn("Switch: "+this.mySwitch.getStringId()+"Slice:"+this.mySlicer.getSliceName()+"Rate limit exceeded");
+			log.warn("Switch: "+this.getSlicer().getSwitchName()+"Slice:"+this.mySlicer.getSliceName()+"Rate limit exceeded");
 			OFError error = new OFError(OFError.OFErrorType.OFPET_BAD_REQUEST);
 			error.setErrorCode(OFBadRequestCode.OFPBRC_EPERM);
 			this.sendError((OFMessage)msg,error);
@@ -776,7 +776,7 @@ public class Proxy {
 		if(!this.valid_header(msg)){
 			//invalid packet don't send it back so we cant send an error
 			//just log and drop it
-			log.error("Slice " + this.getSlicer().getSliceName() + " to switch " + this.mySwitch.getStringId() + "  Invalid Header Rejecting!");
+			log.error("Slice " + this.getSlicer().getSliceName() + " to switch " + this.mySlicer.getSwitchName() + "  Invalid Header Rejecting!");
 			return;
 		}
 		
@@ -856,7 +856,7 @@ public class Proxy {
 				break;
 			}else{
 				log.error("Packet in Rate for Slice: " +
-							this.getSlicer().getSliceName() + ":" + this.getSwitch().getStringId() +
+							this.getSlicer().getSliceName() + ":" + this.getSlicer().getSwitchName() +
 							" has passed the packet in rate limit Disabling slice!!!!");
 				this.setAdminStatus(false);
 				return;
@@ -868,7 +868,7 @@ public class Proxy {
 			OFPortStatus portStatus = (OFPortStatus)msg;
 			OFPhysicalPort port = portStatus.getDesc();
 			if(!this.mySlicer.isPortPartOfSlice(port.getName())){
-				log.debug("Port status even for switch"+this.mySwitch.getStringId()+" port " + port.getName() + " is not allowed for slice"+this.mySlicer.getSliceName());
+				log.debug("Port status even for switch" + this.getSlicer().getSwitchName() + " port " + port.getName() + " is not allowed for slice"+this.mySlicer.getSliceName());
 				return;
 			}
 			

--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/Slicer.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/Slicer.java
@@ -61,4 +61,6 @@ public interface Slicer {
 	boolean getTagManagement();
 	boolean doTimeouts();
 	void setDoTimeouts(boolean doTimeouts);
+	void setSwitchName(String swName);
+	String getSwitchName();
 }

--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/VLANSlicer.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/VLANSlicer.java
@@ -60,6 +60,7 @@ public class VLANSlicer implements Slicer{
 	private int maxFlows;
 	private String name;
 	private int packetInRate;
+	private String swName;
 	private Map<Integer, byte[]> bufferIds;
 	private boolean adminState;
 	private boolean flushOnConnect;
@@ -123,6 +124,14 @@ public class VLANSlicer implements Slicer{
 					}
 				}
 				);
+	}
+	
+	public void setSwitchName(String swName){
+		this.swName = swName;
+	}
+	
+	public String getSwitchName(){
+		return this.swName;
 	}
 	
 	public boolean doTimeouts(){
@@ -395,7 +404,7 @@ public class VLANSlicer implements Slicer{
 			packets.clear();
 			return packets;
 		}
-		log.error("VLAN ID: " + match.getDataLayerVirtualLan());
+		log.debug("VLAN ID: " + match.getDataLayerVirtualLan());
 		if(match.getDataLayerVirtualLan() != -1){
 			log.error("Packet has VID Set");
 			packets.clear();
@@ -794,13 +803,13 @@ public class VLANSlicer implements Slicer{
 		//wildcarded DL_VLAN?
 		Wildcards wc = match.getWildcardObj();
 		if(wc.isWildcarded(Wildcards.Flag.DL_VLAN)){
-			log.debug("Slice: " + this.getSliceName() + ":" + this.sw.getStringId() + " Flow rule VLAN wildcarded.  Denied: " + flowMod.toString());
+			log.debug("Slice: " + this.getSliceName() + ":" + this.getSwitchName() + " Flow rule VLAN wildcarded.  Denied: " + flowMod.toString());
 			return flowMods;
 		}
 		//if you wildcarded the vlan then tough we are blowing up now
 		//we require an input vlan
 		if(match.getDataLayerVirtualLan() == 0){
-			log.debug("Slice: " + this.getSliceName() + ":" + this.sw.getStringId() + " Flow rule VLAN wildcarded.  Denied: " + flowMod.toString());
+			log.debug("Slice: " + this.getSliceName() + ":" + this.getSwitchName() + " Flow rule VLAN wildcarded.  Denied: " + flowMod.toString());
 			return flowMods;
 		}
 		
@@ -845,7 +854,7 @@ public class VLANSlicer implements Slicer{
 					}catch (CloneNotSupportedException e){
 						log.error("This can't happen in the real world");
 					}catch (Exception e){
-						log.error("WTF");
+						
 					}
 				}
 			}
@@ -903,7 +912,7 @@ public class VLANSlicer implements Slicer{
 		//need to do something special if you do have access to all ports
 		Wildcards wc = match.getWildcardObj();
 		if(wc.isWildcarded(Wildcards.Flag.IN_PORT)){
-			log.debug("Slice: " + this.getSliceName() + ":" + this.sw.getStringId() + " Flow rule VLAN wildcarded.  Denied: " + flowMod.toString());
+			log.debug("Slice: " + this.getSliceName() + ":" + this.getSwitchName() + " Flow rule VLAN wildcarded.  Denied: " + flowMod.toString());
 			return false;
 		}
 		if(match.getInputPort() == 0){
@@ -914,7 +923,7 @@ public class VLANSlicer implements Slicer{
 		
 		//checking for wildcarded input vlan
 		if(wc.isWildcarded(Wildcards.Flag.DL_VLAN)){
-			log.debug("Slice: " + this.getSliceName() + ":" + this.sw.getStringId() + " Flow rule VLAN wildcarded.  Denied: " + flowMod.toString());
+			log.debug("Slice: " + this.getSliceName() + ":" + this.getSwitchName() + " Flow rule VLAN wildcarded.  Denied: " + flowMod.toString());
 			return false;
 		}
 		//we require an input vlan


### PR DESCRIPTION
Now when we log messages from Slicer or Proxy it will contain the
switch name instead of the DPID, in the attempt to make the logs easier
for everyone to process
