### PR TITLE
Issue=10285 fixing flow stat reply wildcards and actions in managed tag mode

### DIFF
--- a/src/test/java/edu/iu/grnoc/flowspace_firewall/FlowStatSlicerTest.java
+++ b/src/test/java/edu/iu/grnoc/flowspace_firewall/FlowStatSlicerTest.java
@@ -31,9 +31,11 @@ import net.floodlightcontroller.core.ImmutablePort;
 import org.junit.Test;
 import org.junit.Before;
 import org.openflow.protocol.OFMatch;
+import org.openflow.protocol.Wildcards;
 import org.openflow.protocol.Wildcards.Flag;
 import org.openflow.protocol.action.OFAction;
 import org.openflow.protocol.action.OFActionOutput;
+import org.openflow.protocol.action.OFActionType;
 import org.openflow.protocol.action.OFActionVirtualLanIdentifier;
 import org.openflow.protocol.statistics.OFFlowStatisticsReply;
 import org.openflow.protocol.statistics.OFStatistics;
@@ -48,8 +50,10 @@ public class FlowStatSlicerTest {
 	List <OFStatistics> allowedStats;
 	List <OFStatistics> noAllowedStats;
 	List <OFStatistics> mixedStats;
+	List <OFStatistics> managedStats;
 	IOFSwitch sw;
 	VLANSlicer slicer;
+	VLANSlicer managedSlicer;
 	PortConfig pConfig;
 	PortConfig pConfig2;
 	PortConfig pConfig3;
@@ -124,6 +128,92 @@ public class FlowStatSlicerTest {
 		allowedStats.add(stat);
 	}
 
+	public void buildManagedTagStats(){
+		List<OFAction> actions = new ArrayList<OFAction>();
+		OFActionVirtualLanIdentifier setVlanID = new OFActionVirtualLanIdentifier();
+		setVlanID.setVirtualLanIdentifier((short)200);
+		actions.add(setVlanID);
+		OFActionOutput output = new OFActionOutput();
+		output.setPort((short)1);
+		actions.add(output);
+		
+		OFMatch match = new OFMatch();
+		match.setInputPort((short)1);
+		match.setDataLayerVirtualLan((short)200);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
+		//all allowed stats
+		managedStats = new ArrayList<OFStatistics>();
+		OFFlowStatisticsReply stat = new OFFlowStatisticsReply();
+		stat.setActions(actions);
+		stat.setMatch(match);
+		stat.setByteCount(123126L);
+		managedStats.add(stat);
+		
+		actions = new ArrayList<OFAction>();
+		output = new OFActionOutput();
+		output.setPort((short)2);
+		actions.add(output);
+		match = new OFMatch();
+		match.setInputPort((short)2);
+		match.setDataLayerVirtualLan((short)200);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
+		stat = new OFFlowStatisticsReply();
+		stat.setActions(actions);
+		stat.setMatch(match);
+		stat.setByteCount(123125L);
+		managedStats.add(stat);
+		
+		actions = new ArrayList<OFAction>();
+		output = new OFActionOutput();
+		output.setPort((short)3);
+		actions.add(output);
+		match = new OFMatch();
+		match.setInputPort((short)3);
+		match.setDataLayerVirtualLan((short)200);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
+		stat = new OFFlowStatisticsReply();
+		stat.setActions(actions);
+		stat.setMatch(match);
+		stat.setByteCount(123124L);
+		managedStats.add(stat);
+		
+		actions = new ArrayList<OFAction>();
+		output = new OFActionOutput();
+		output.setPort((short)5);
+		actions.add(output);
+		match = new OFMatch();
+		match.setInputPort((short)5);
+		match.setDataLayerVirtualLan((short)200);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
+		stat = new OFFlowStatisticsReply();
+		stat.setActions(actions);
+		stat.setMatch(match);
+		stat.setByteCount(123123L);
+		managedStats.add(stat);
+		
+		
+		actions = new ArrayList<OFAction>();
+		output = new OFActionOutput();
+		output.setPort((short)5);
+		actions.add(output);
+		match = new OFMatch();
+		match.setInputPort((short)5);
+		match.setDataLayerVirtualLan((short)100);
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.DL_VLAN));
+		match.setWildcards(match.getWildcardObj().matchOn(Flag.IN_PORT));
+		stat = new OFFlowStatisticsReply();
+		stat.setActions(actions);
+		stat.setMatch(match);
+		stat.setByteCount(123123L);
+		managedStats.add(stat);
+	}
+
+	
+	
 	public void buildNoAllowedStats(){
 		//no allowed stats
 		noAllowedStats = new ArrayList<OFStatistics>();
@@ -235,6 +325,7 @@ public class FlowStatSlicerTest {
 		buildAllowedStats();
 		buildNoAllowedStats();
 		buildMixedStats();
+		buildManagedTagStats();
 
 		
 	}
@@ -291,6 +382,8 @@ public class FlowStatSlicerTest {
         assertEquals("ports == sw.getPorts()", ports, sw.getPorts());
         
         slicer = new VLANSlicer();
+        managedSlicer = new VLANSlicer();
+        managedSlicer.setTagManagement(true);
 		
 		pConfig = new PortConfig();
 		pConfig.setPortName("foo");
@@ -300,6 +393,12 @@ public class FlowStatSlicerTest {
 		pConfig.setVLANRange(range);
 		slicer.setPortConfig("foo", pConfig);
 		
+		PortConfig managedPConfig = new PortConfig();
+		range = new VLANRange();
+		range.setVlanAvail((short)200, true);
+		managedPConfig.setVLANRange(range);
+		managedSlicer.setPortConfig("foo", managedPConfig);
+		
 		pConfig2 = new PortConfig();
 		pConfig.setPortName("foo2");
 		range = new VLANRange();
@@ -307,7 +406,13 @@ public class FlowStatSlicerTest {
 		range.setVlanAvail((short)1000,true);
 		pConfig2.setVLANRange(range);
 		slicer.setPortConfig("foo2", pConfig2);
-
+		
+		managedPConfig = new PortConfig();
+		range = new VLANRange();
+		range.setVlanAvail((short)200, true);
+		managedPConfig.setVLANRange(range);
+		managedSlicer.setPortConfig("foo2", managedPConfig);
+		
 		pConfig3 = new PortConfig();
 		pConfig.setPortName("foo3");
 		range = new VLANRange();
@@ -315,6 +420,12 @@ public class FlowStatSlicerTest {
 		range.setVlanAvail((short)1000,true);
 		pConfig3.setVLANRange(range);
 		slicer.setPortConfig("foo3", pConfig3);
+		
+		managedPConfig = new PortConfig();
+		range = new VLANRange();
+		range.setVlanAvail((short)200, true);
+		managedPConfig.setVLANRange(range);
+		managedSlicer.setPortConfig("foo3", managedPConfig);
 		
 		pConfig5 = new PortConfig();
 		pConfig.setPortName("foo5");
@@ -324,7 +435,15 @@ public class FlowStatSlicerTest {
 		pConfig5.setVLANRange(range);
 		slicer.setPortConfig("foo5", pConfig5);
 		
+		managedPConfig = new PortConfig();
+		range = new VLANRange();
+		range.setVlanAvail((short)200, true);
+		managedPConfig.setVLANRange(range);
+		managedSlicer.setPortConfig("foo5", managedPConfig);
+		
 		slicer.setSwitch(sw);
+		managedSlicer.setSwitch(sw);
+		
 	}
 	
 	@Test
@@ -362,5 +481,25 @@ public class FlowStatSlicerTest {
 		assertEquals("Sliced stats", 0, slicedStats.size());
 	}
 	
+	@Test
+	public void testsManagedTagSliceStatsNoStats(){
+		List <OFStatistics> slicedStats = FlowStatSlicer.SliceStats(managedSlicer,  new ArrayList<OFStatistics>());
+		assertNotNull("Sliced Stats with no allowed stats returend ok", slicedStats);
+		assertEquals("Sliced stats", 0, slicedStats.size());
+	}
+	
+	@Test
+	public void testsManagedTagSliceStats(){
+		List <OFStatistics> slicedStats = FlowStatSlicer.SliceStats(managedSlicer,  managedStats);
+		assertNotNull("Sliced Stats with no allowed stats returend ok", slicedStats);
+		assertEquals("Sliced stats", 4, slicedStats.size());
+		
+		OFFlowStatisticsReply stat = (OFFlowStatisticsReply) slicedStats.get(0);
+		assertTrue( stat.getMatch().getWildcardObj().isWildcarded(Wildcards.Flag.DL_VLAN));
+		
+		assertTrue( stat.getActions().size() == 1);
+		assertTrue( stat.getActions().get(0).getType() == OFActionType.OUTPUT);
+		
+	}
 
 }


### PR DESCRIPTION
When in managed tag mode flow stats were not properly being wildcarded and the set_vlan_id / strip_vlan actions were not properly being removed.  Causing controllers that were looking at these bits to do the incorrect things.