### PR TITLE
fixing some issues found during burn-in testing

### DIFF
--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/FlowSpaceFirewall.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/FlowSpaceFirewall.java
@@ -430,8 +430,8 @@ public class FlowSpaceFirewall implements IFloodlightModule, IOFMessageListener,
 		}catch(InvalidConfigException e){
 			logger.error(e.getMsg());
 		}
-
-		if(this.slices.size() == 0){
+		
+		if(this.slices == null || this.slices.size() == 0){
 			logger.error("Problem with the configuration file!");
 			throw new FloodlightModuleException("Problem with the Config!");
 		}

--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/FlowSpaceFirewall.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/FlowSpaceFirewall.java
@@ -101,7 +101,12 @@ public class FlowSpaceFirewall implements IFloodlightModule, IOFMessageListener,
         
         //belts and suspenders here
         //we don't want there to be a lot of switches with this
-        this.switchRemoved(switchId);
+        for(IOFSwitch tmpSw : this.switches){
+        	if(tmpSw.getId() == switchId){
+        		logger.error("Switch is already listed as connected!  Removing!");
+        		this.switchRemoved(switchId);
+        	}
+        }
         this.switches.add(sw);
         //loop through all slices
         for(HashMap<Long, Slicer> slice: slices){
@@ -192,17 +197,12 @@ public class FlowSpaceFirewall implements IFloodlightModule, IOFMessageListener,
 				switchIt.remove();
 			}
 		}
-		
-		
+				
 		this.statsCacher.clearCache(switchId);
 		
 		while(it.hasNext()){
 			Proxy p = it.next();
-			try{
-				p.disconnect();
-			}catch(Exception e){
-				logger.error("Error Occured while disconnecting proxy!");
-			}
+			p.disconnect();
 			it.remove();
 		}
 				

--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/FlowSpaceFirewall.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/FlowSpaceFirewall.java
@@ -99,6 +99,9 @@ public class FlowSpaceFirewall implements IFloodlightModule, IOFMessageListener,
         logger.info("Switch " + switchId + " has joined");
         IOFSwitch sw = floodlightProvider.getSwitch(switchId);
         
+        //belts and suspenders here
+        //we don't want there to be a lot of switches with this
+        this.switchRemoved(switchId);
         this.switches.add(sw);
         //loop through all slices
         for(HashMap<Long, Slicer> slice: slices){
@@ -182,20 +185,25 @@ public class FlowSpaceFirewall implements IFloodlightModule, IOFMessageListener,
 		List <Proxy> proxies = controllerConnector.getSwitchProxies(switchId);
 		Iterator <Proxy> it = proxies.iterator();
 
-		while(it.hasNext()){
-			Proxy p = it.next();
-			p.disconnect();
-			it.remove();
-		}
-		
-		this.statsCacher.clearCache(switchId);
-		
 		Iterator <IOFSwitch> switchIt = this.switches.iterator();
 		while(switchIt.hasNext()){
 			IOFSwitch tmpSwitch = switchIt.next();
 			if(tmpSwitch.getId() == switchId){
 				switchIt.remove();
 			}
+		}
+		
+		
+		this.statsCacher.clearCache(switchId);
+		
+		while(it.hasNext()){
+			Proxy p = it.next();
+			try{
+				p.disconnect();
+			}catch(Exception e){
+				logger.error("Error Occured while disconnecting proxy!");
+			}
+			it.remove();
 		}
 				
 	}

--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/FlowStatCacher.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/FlowStatCacher.java
@@ -80,7 +80,7 @@ public class FlowStatCacher extends TimerTask{
 		
 		while(it.hasNext()){
 			IOFSwitch sw = it.next();
-			log.debug("Getting stats for switch: " + sw.getId());
+			log.debug("Getting stats for switch: " + sw.getStringId() );
 			List<OFStatistics> statsReply = getFlowStatsForSwitch(sw);
 			statsCache.setFlowCache(sw.getId(), statsReply);
 			HashMap<Short, OFStatistics> portStatsReply = getPortStatsForSwitch(sw);
@@ -218,7 +218,7 @@ public class FlowStatCacher extends TimerTask{
         try {
         	future = sw.queryStatistics(req);
         	log.debug(future.toString());
-        	values = future.get(20, TimeUnit.SECONDS);
+        	values = future.get(10, TimeUnit.SECONDS);
         	log.debug(values.toString());
         	if(values != null){
             	for(OFStatistics stat : values){

--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/Proxy.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/Proxy.java
@@ -255,6 +255,9 @@ public class Proxy {
 	 * disconnect from the controller
 	 */
 	public void disconnect(){
+		if(myController == null){
+			return;
+		}
 		if(myController.isConnected()){
 			myController.disconnect();
 		}


### PR DESCRIPTION
There was an issue found during burn-in testing that caused FlowStats to not be updated at a proper interval.  State tracking of which switches were connected was failing when a switch would join and be removed before the controller connector could connect to a controller.  This caused a null pointer exception that was eaten by floodlight and ultimately left our array of switches to be connected to grow.  Each one of these left over switches caused the amount of time for the FlowStats collection to increase by 30sec.  Causing OESS diffs to be inaccurate