### PR TITLE
Set total_len when stripping a VLAN from pkt-in

### DIFF
--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/Proxy.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/Proxy.java
@@ -905,7 +905,13 @@ public class Proxy {
 					newPkt.deserialize(pktData,0,pktData.length);
 					newPkt.setEtherType(newPkt.getEtherType());
 					newPkt.setVlanID(Ethernet.VLAN_UNTAGGED);
-					pcktIn.setPacketData(newPkt.serialize());
+					
+					//Set the packet data based on the length of the serialize function's returned
+					//value.  Do it this way because serialize() might remove a number of padding bytes,
+					//so we cannot just assume the number of bytes removed will be 4.
+					byte[] newPktData = newPkt.serialize();
+					pcktIn.setPacketData(newPktData);
+					pcktIn.setTotalLength((short) newPktData.length);
 				}
 				break;
 			}else{


### PR DESCRIPTION
The ofp_packet_in total_len field is not adjusted by any library
functions when we strip a VLAN tag from a data packet.  In addition,
deserializing and reserializing a packet might cause it to lose some
padding bytes.  To account for this, just set the total length to
whatever the length of the serialized packet is.