### PR TITLE
fixing a possible issue in the cache

### DIFF
--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/FlowStatCache.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/FlowStatCache.java
@@ -425,6 +425,13 @@ public class FlowStatCache{
 				FSFWOFFlowStatisticsReply parentStat = cachedStat.getParentStat();
 				OFFlowMod flow = this.buildFlowMod(parentStat);
 				Slicer slice = this.parent.getProxy(switchId, parentStat.getSliceName()).getSlicer();
+				if(slice == null){
+					//uh ok so this flow is not a part of any slice
+					//kind of a convoluted situation here
+					//delete the flow
+					this.deleteFlow(switchId, parentStat);
+					return;
+				}
 				//get a list of all flows that this will invalidate
 				List<OFFlowMod> flows;
 				if(slice.getTagManagement()){


### PR DESCRIPTION
It is possible to get flows installed on a switch that are not a part
of any slice any more (after a config modification) that will then
cause a stacktrace in the stats cacher.  When we detect this case we now remove the flow from the switch and move on to the next flow