### PR TITLE
re-writing the descrStats reply to include FSFW

### DIFF
--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/Proxy.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/Proxy.java
@@ -615,6 +615,9 @@ public class Proxy {
 		OFStatisticsReply reply = new OFStatisticsReply();
 		reply.setStatisticType(OFStatisticsType.DESC);
 		List<OFStatistics> stats = new ArrayList<OFStatistics>();
+		descrStats.setHardwareDescription("FSFW: " + descrStats.getHardwareDescription());
+		descrStats.setManufacturerDescription("FSFW: " + descrStats.getManufacturerDescription());
+		descrStats.setSoftwareDescription("FSFW: " + descrStats.getSoftwareDescription());
 		stats.add(descrStats);
 		reply.setStatistics(stats);
 		reply.setXid(msg.getXid());


### PR DESCRIPTION
it was requrested that we re-write the descrStats so that they show
FSFW in the string to indicate that it is not the same as the device