### PR TITLE
Issue=11806 fsfw resetting counters

### DIFF
--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/FSFWOFFlowStatisticsReply.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/FSFWOFFlowStatisticsReply.java
@@ -1,5 +1,6 @@
 package edu.iu.grnoc.flowspace_firewall;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.openflow.protocol.action.OFAction;
@@ -17,6 +18,33 @@ public class FSFWOFFlowStatisticsReply extends OFFlowStatisticsReply{
 	private String sliceName;
 	private FSFWOFFlowStatisticsReply parentStat;
 	private boolean hasParent = false;
+
+	
+	public static FSFWOFFlowStatisticsReply clone(OFFlowStatisticsReply stat) throws CloneNotSupportedException{
+		FSFWOFFlowStatisticsReply newStat = new FSFWOFFlowStatisticsReply();
+		
+		newStat.setByteCount(stat.getByteCount());
+		newStat.setPacketCount(stat.getPacketCount());
+		newStat.setCookie(stat.getCookie());
+		
+		//need to copy the action list
+		List<OFAction> acts = new ArrayList<OFAction>();
+		for(OFAction act : stat.getActions()){
+			acts.add(act.clone());
+		}
+		
+		newStat.setActions(acts);
+		newStat.setMatch(stat.getMatch().clone());
+		newStat.setDurationNanoseconds(stat.getDurationNanoseconds());
+		newStat.setDurationSeconds(stat.getDurationSeconds());
+		newStat.setHardTimeout(stat.getHardTimeout());
+		newStat.setIdleTimeout(stat.getIdleTimeout());
+		newStat.setPriority(stat.getPriority());
+		newStat.setTableId(stat.getTableId());
+		newStat.setLength((short)newStat.getLength());
+		
+		return newStat;
+	}
 	
 	public boolean isVerified(){
 		return verified;

--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/FlowStatCache.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/FlowStatCache.java
@@ -700,19 +700,27 @@ public class FlowStatCache{
 			HashMap<String, List<OFStatistics>> tmpStats = sliced.get(switchId);
 			if(tmpStats.containsKey(sliceName)){				
 				//create a copy of the array so we can manipulate it
-				List<OFStatistics> stats = new ArrayList<OFStatistics>(tmpStats.get(sliceName));
+				List<OFStatistics> slicedStats = new ArrayList<OFStatistics>();				
+				List<OFStatistics> stats = tmpStats.get(sliceName);
 
 				//we only want verified flows to appear
 				Iterator<OFStatistics> it = stats.iterator();
 				while(it.hasNext()){
 					FSFWOFFlowStatisticsReply flowStat = (FSFWOFFlowStatisticsReply)it.next();
 					if(flowStat.toBeDeleted() || !flowStat.isVerified()){
-						it.remove();
+						
+					}else{
+						try{
+							FSFWOFFlowStatisticsReply tmpFlowStat = FSFWOFFlowStatisticsReply.clone(flowStat);
+							slicedStats.add(tmpFlowStat);
+						}catch(CloneNotSupportedException e){
+							log.error("Unable to clone FlowStat!");
+						}
 					}
 				}
 				
-				log.debug("Returning " + stats.size() + " flow stats");
-				return stats;
+				log.debug("Returning " + slicedStats.size() + " flow stats");
+				return slicedStats;
 			}
 			log.debug("Switch cache has no slice cache named: " + sliceName);
 			return new ArrayList<OFStatistics>();

--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/Proxy.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/Proxy.java
@@ -1007,7 +1007,7 @@ public class Proxy {
 			
 			if(mySlicer.getTagManagement()){
 				removedFlow.getMatch().setDataLayerVirtualLan((short)0);
-				removedFlow.getMatch().getWildcardObj().wildcard(Wildcards.Flag.DL_VLAN);
+				removedFlow.getMatch().setWildcards(removedFlow.getMatch().getWildcardObj().wildcard(Wildcards.Flag.DL_VLAN));
 				msg = removedFlow;
 			}
 			

--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/SwitchConfig.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/SwitchConfig.java
@@ -29,7 +29,7 @@ public class SwitchConfig {
 	}
 	
 	public boolean getInstallDefaultDrop(){
-		return this.flush_on_connect;
+		return this.install_default_drop;
 	}
 	
 	public void setName(String value){

--- a/src/main/java/edu/iu/grnoc/flowspace_firewall/web/SlicerStatusResource.java
+++ b/src/main/java/edu/iu/grnoc/flowspace_firewall/web/SlicerStatusResource.java
@@ -83,12 +83,12 @@ public class SlicerStatusResource extends ServerResource{
 		
 		results.put("flow_rate", myProxy.getSlicer().getRate() );
 		results.put("total_flows", myProxy.getFlowCount());
-		results.put("max_flows_per_sec",  myProxy.getSlicer().getMaxFlows());
+		results.put("max_flows_per_sec", myProxy.getSlicer().getMaxFlowRate());
 		results.put("connected", myProxy.connected());
 		results.put("DPID", myProxy.getSwitch().getStringId());
 		results.put("max_packet_in_rate",  myProxy.getSlicer().getPacketInRate());
 		results.put("packet_in_rate", myProxy.getPacketInRate());
-		results.put("max_flow_rule", myProxy.getSlicer().getMaxFlowRate());
+		results.put("max_flow_rule", myProxy.getSlicer().getMaxFlows());
 		
 		return results;
 		


### PR DESCRIPTION
We determined that FSFW while thread safe was updating the stats in the returned results as they were being sent.  This was causing in some cases the byte count to be 0 for some flow rules (race condition) this is fixed and unit tests have been added to prevent this in the future